### PR TITLE
Set ruby2.5 back to default

### DIFF
--- a/conf/port-options.conf
+++ b/conf/port-options.conf
@@ -3,3 +3,4 @@ graphics_ImageMagick_UNSET=16BIT_PIXEL
 www_nextcloud_SET=IMAGICK
 net-p2p_bitcoin-daemon_SET=ZMQ
 multimedia_vapoursynth_UNSET=DOCS
+DEFAULT_VERSIONS+=ruby=2.5


### PR DESCRIPTION
On FreeBSD 11.2 Jails ruby2.6 is broken, and breaks gitlabs update.

run database migrations..

> /usr/local/lib/ruby/gems/2.6/gems/ffi-1.11.1/lib/ffi/library.rb:112: [BUG] Illegal instruction at 0x000000081c8e10ff
> ruby 2.6.4p104 (2019-08-28 revision 67798) [amd64-freebsd11]
> 
> -- Control frame information -----------------------------------------------
> c:0042 p:---- s:0203 e:000202 CFUNC  :open
> c:0041 p:0022 s:0197 e:000196 BLOCK  /usr/local/lib/ruby/gems/2.6/gems/ffi-1.11.1/lib/ffi/library.rb:112 [FINISH]
> c:0040 p:---- s:0188 e:000187 CFUNC  :each
> c:0039 p:0113 s:0184 e:000183 BLOCK  /usr/local/lib/ruby/gems/2.6/gems/ffi-1.11.1/lib/ffi/library.rb:109 [FINISH]
> c:0038 p:---- s:0177 e:000176 CFUNC  :map
> c:0037 p:0069 s:0173 e:000172 METHOD /usr/local/lib/ruby/gems/2.6/gems/ffi-1.11.1/lib/ffi/library.rb:99
> c:0036 p:0079 s:0166 e:000165 CLASS  /usr/local/lib/ruby/gems/2.6/gems/sassc-2.1.0/lib/sassc/native.rb:10
> c:0035 p:0007 s:0162 e:000161 CLASS  /usr/local/lib/ruby/gems/2.6/gems/sassc-2.1.0/lib/sassc/native.rb:6
> c:0034 p:0014 s:0159 e:000158 TOP    /usr/local/lib/ruby/gems/2.6/gems/sassc-2.1.0/lib/sassc/native.rb:5 [FINISH]
